### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      javascript:
+        patterns: ["*"]
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Common setup
         uses: ./.github/workflows/setup

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .nvmrc
         cache: npm


### PR DESCRIPTION
Adds a Dependabot configuration for weekly grouped dependency updates:

- `github-actions`: weekly, grouped, 7-day cooldown
- `npm`: weekly, all dependencies grouped, 7-day cooldown

Also pins all workflow actions to commit hashes and bumps them to latest releases:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6.0.3 |
| actions/setup-node | v4 | v6.4.0 |