### PR TITLE
Link all audit reports to their repositories and final commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ See [full report](MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021
 
 ### 05-2021 MixBytes Audit: stETH price oracle
 
+Audited at commit `1033b3e8` of `lidofinance/curve-merkle-oracle` (repository is private).
+
 - Total Issues: 7 (4 Fixed, 1 No issue, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -403,6 +405,8 @@ Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4
 See [full report](Statemind%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more details.
 
 ### 05-2023 Statemind Lido V2 Upgrade Template Audit
+
+Audited at commit `a19c6b7e` of `lidofinance/lido-dao`.
 
 - Total Issues: 14 (7 Fixed, 7 Acknowledged)
 - Critical Issues: 0

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ See [full report](MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021
 
 ### 05-2021 MixBytes Audit: stETH price oracle
 
-Audited at commit [`1033b3e`](https://github.com/lidofinance/curve-merkle-oracle/tree/1033b3e84142317ffd8f366b52e489d5eb49c73f).
-
 - Total Issues: 7 (4 Fixed, 1 No issue, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -405,8 +403,6 @@ Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4
 See [full report](Statemind%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more details.
 
 ### 05-2023 Statemind Lido V2 Upgrade Template Audit
-
-Audited at commit [`a19c6b7`](https://github.com/lidofinance/lido-dao/tree/a19c6b7e2d661de12e2ba585c251c8d70a1da230).
 
 - Total Issues: 14 (7 Fixed, 7 Acknowledged)
 - Critical Issues: 0

--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,8 @@ Audits of the Mellow vault infrastructure powering Lido Earn and of the Lido-sid
 
 ### 07-2025 Sherlock Mellow Protocol Security Review (Best Efforts Audit Contest)
 
+Audited at final commit [`72f689f`](https://github.com/mellow-finance/flexible-vaults/tree/72f689f965e4ac1a4c2bcfb645a8b5416cf740c7).
+
 - Total Issues: 15 (all Fixed or Acknowledged)
 - High Issues: 6
 - Medium Issues: 9
@@ -1137,6 +1139,8 @@ Audits of the Mellow vault infrastructure powering Lido Earn and of the Lido-sid
 See [full report](earn/2025-07-28_Sherlock_Mellow-Core-Vaults.pdf) for more details.
 
 ### 09-2025 Nethermind Mellow Core Vaults Security Review (NM-0587)
+
+Audited at commit [`69413d5`](https://github.com/mellow-finance/flexible-vaults/tree/69413d545f788c0ad4ff7fe08085fb55589c5c61).
 
 - Total Issues: 5 (4 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -1149,11 +1153,15 @@ See [full report](earn/2025-09-03_Nethermind_Mellow-Core-Vaults.pdf) for more de
 
 ### 10-2025 Nethermind Mellow Migrator Security Review (NM-0682)
 
+Audited at commit [`a04e285`](https://github.com/mellow-finance/flexible-vaults/tree/a04e285fe859dcd720e8b827628a98d0cc46c02c).
+
 - Total Issues: 0
 
 See [full report](earn/2025-10-15_Nethermind_NM-0682_Mellow.pdf) for more details.
 
 ### 11-2025 Nethermind Mellow Oracle Submitter Security Review (NM-0703)
+
+Audited at commit [`d3bf393`](https://github.com/mellow-finance/flexible-vaults/tree/d3bf39373357f9f2049eddda951c0428ce305b6c).
 
 - Total Issues: 2 (2 Acknowledged)
 - Critical Issues: 0
@@ -1166,6 +1174,8 @@ See [full report](earn/2025-11-17_Nethermind_NM-0703_Mellow.pdf) for more detail
 
 ### 11-2025 Nethermind Mellow Swap Module Security Review (NM-0735)
 
+Audited at commit [`688382e`](https://github.com/mellow-finance/flexible-vaults/tree/688382ebb8860cb4e0b9336f9f2349e159ac3d05).
+
 - Total Issues: 2 (2 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -1177,11 +1187,15 @@ See [full report](earn/2025-11-19_Nethermind_NM-0735_Mellow.pdf) for more detail
 
 ### 12-2025 Nethermind Mellow SyncDepositQueue Security Review (NM-0758)
 
+Audited at commit [`f4c311b`](https://github.com/mellow-finance/flexible-vaults/tree/f4c311b73c3b2eaae01e8e668f6df2fef6aee048).
+
 - Total Issues: 0
 
 See [full report](earn/2025-12-09_Nethermind_NM-0758_Mellow.pdf) for more details.
 
 ### 01-2026 Nethermind Mellow BurnableTokenizedShareManager Security Review (NM-0798)
+
+Audited at commit [`09d8155`](https://github.com/mellow-finance/flexible-vaults/tree/09d81553d719f38ace8a646551d6b043c345df8a).
 
 - Total Issues: 0
 
@@ -1189,11 +1203,15 @@ See [full report](earn/2026-01-07_Nethermind_NM-0798_Mellow.pdf) for more detail
 
 ### 01-2026 Nethermind Mellow Redeem Queue Fee Fix Security Review (NM-0812)
 
+Audited at commit [`685be83`](https://github.com/mellow-finance/flexible-vaults/tree/685be8395aef17e41615cf0bfebfbfbd51c3b582).
+
 - Total Issues: 0
 
 See [full report](earn/2026-01-21_Nethermind_NM-0812_Mellow.pdf) for more details.
 
 ### 03-2026 Nethermind Mellow SyncDepositQueue Re-Review (NM-0758)
+
+Audited at commit [`c9c7181`](https://github.com/mellow-finance/flexible-vaults/tree/c9c71818f0a8bead183f9860db3b8bbceb7b8f37).
 
 Updated review reflecting a fix identified on February 27, 2026.
 
@@ -1202,6 +1220,8 @@ Updated review reflecting a fix identified on February 27, 2026.
 See [full report](earn/2026-03-02_Nethermind_NM-0758_Mellow.pdf) for more details.
 
 ### 04-2026 Nethermind Mellow PermissionedChainlinkOracle Security Review (NM-0891)
+
+Audited at commit [`bcf37ae`](https://github.com/mellow-finance/flexible-vaults/tree/bcf37aef95cefc45be9c4b8988126c5f7d3d6788).
 
 - Total Issues: 1 (1 Acknowledged)
 - Critical Issues: 0
@@ -1214,6 +1234,8 @@ See [full report](earn/2026-04-13_Nethermind_NM-0891_Mellow.pdf) for more detail
 
 ### 04-2026 MixBytes ATokenWstETHSwap Security Audit
 
+Audited at commit [`00432c9`](https://github.com/lidofinance/atoken-wsteth-swap/tree/00432c9a76049dfd9ab0804dfa892ff3ea4b89af).
+
 - Total Issues: 6 (6 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -1223,6 +1245,8 @@ See [full report](earn/2026-04-13_Nethermind_NM-0891_Mellow.pdf) for more detail
 See [full report](earn/Lido%20ATokenWstETHSwap%20Security%20Audit%20Report.pdf) for more details.
 
 ### 04-2026 MixBytes GGV Migrator Security Audit
+
+Audited at commit [`da93276`](https://github.com/mellow-finance/flexible-vaults/tree/da932764a3e9fbc71127f39aa1006a2ddf73d46c).
 
 - Total Issues: 2 (2 Acknowledged)
 - Critical Issues: 0
@@ -1234,6 +1258,8 @@ See [full report](earn/Lido%20GGV%20Migrator%20Security%20Audit%20Report.pdf) fo
 
 ### 05-2026 MixBytes GGV Migrator V2 Security Audit
 
+Audited at commit [`07adcc0`](https://github.com/mellow-finance/flexible-vaults/tree/07adcc04ecc3279edb9de0b67194ab0a91dbe025).
+
 - Total Issues: 1 (1 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -1243,6 +1269,8 @@ See [full report](earn/Lido%20GGV%20Migrator%20Security%20Audit%20Report.pdf) fo
 See [full report](earn/Lido%20GGV%20Migrator%20V2%20Security%20Audit%20Report.pdf) for more details.
 
 ### 06-2026 MixBytes AAVE Migrator Security Audit
+
+Audited at commit [`82b1849`](https://github.com/mellow-finance/flexible-vaults/tree/82b1849c30f26f0c2a7940feb28bc6c5937ca791).
 
 - Total Issues: 0
 

--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,8 @@ See [full report](L2/Mantle-2023-09-Verilog-L2-ERC20-Token-Bridge-Audit-Report.p
 
 ### 10-2023 Cantina zkSync Lido Bridge Audit
 
+Audited at commit [`fa6a77e`](https://github.com/txfusion/lido-l2/tree/fa6a77e694a34dc6f03d57bb8c934941e554ac9d).
+
 - Total Issues: 22 (15 Fixed, 3 Acknowledged, 4 No issue)
 - Critical Issues: 1 (1 Fixed)
 - High Issues: 0
@@ -1286,6 +1288,8 @@ The deployed contracts are verified against the [wstETH on Base](https://docs.li
 See [full report](L2/Mode-2024-07-18-Cantina-wstETH-deployment-verification.pdf) for more details.
 
 ### 07-2024 MixBytes Lido a.DI Audit
+
+Audited at commit [`41c8197`](https://github.com/lidofinance/aave-delivery-infrastructure/tree/41c81975c2ce5b430b283e6f4aab922c3bde1555).
 
 - Total Issues: 13 (13 Acknowledged)
 - Critical Issues: 0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ See [full report](MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021
 
 ### 05-2021 MixBytes Audit: stETH price oracle
 
+Audited at commit: private source repository; no public commit available.
+
 - Total Issues: 7 (4 Fixed, 1 No issue, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -404,6 +406,8 @@ See [full report](Statemind%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more d
 
 ### 05-2023 Statemind Lido V2 Upgrade Template Audit
 
+Audited at commit: audited commit is not public.
+
 - Total Issues: 14 (7 Fixed, 7 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -456,6 +460,8 @@ Audited at commit [`4467895`](https://github.com/lidofinance/lido-oracle/tree/44
 See [full report](Oxorio%20Lido%20V2%20Off-chain%20Audit%20Report%2006-23.pdf) for more details.
 
 ### 10-2023 Statemind Lido roles analysis
+
+Audited at commit: not applicable; on-chain analysis, no source commit.
 
 | Impact severity \ Attack feasibility | Low | Medium | High |
 | ------------------------------------ | --- | ------ | ---- |
@@ -1313,6 +1319,8 @@ See [full report](L2/Zircuit_2024-10-02-Quantstamp-wstETH-deployment-verificatio
 
 ### 11-2024 Nethermind Security wstETH on Starknet Deployment Verification
 
+Audited at commit: not applicable; deployment verification, no source commit.
+
 The deployed contracts are verified in accordance to the [proposal](https://research.lido.fi/t/wsteth-deployment-on-starknet/6335/9)
 
 See the [full report](L2/Starknet-2024-11-14-deployment-verification.pdf) for more details.
@@ -1357,7 +1365,7 @@ Audits of the Mellow vault infrastructure powering Lido Earn and of the Lido-sid
 
 ### 07-2025 Sherlock Mellow Protocol Security Review (Best Efforts Audit Contest)
 
-Audited at final commit [`72f689f`](https://github.com/mellow-finance/flexible-vaults/tree/72f689f965e4ac1a4c2bcfb645a8b5416cf740c7).
+Audited at commit [`72f689f`](https://github.com/mellow-finance/flexible-vaults/tree/72f689f965e4ac1a4c2bcfb645a8b5416cf740c7).
 
 - Total Issues: 15 (all Fixed or Acknowledged)
 - High Issues: 6
@@ -1368,7 +1376,7 @@ See [full report](earn/2025-07-28_Sherlock_Mellow-Core-Vaults.pdf) for more deta
 
 ### 09-2025 Nethermind Mellow Core Vaults Security Review (NM-0587)
 
-Audited at commit [`69413d5`](https://github.com/mellow-finance/flexible-vaults/tree/69413d545f788c0ad4ff7fe08085fb55589c5c61).
+Audited at commit [`72f689f`](https://github.com/mellow-finance/flexible-vaults/tree/72f689f965e4ac1a4c2bcfb645a8b5416cf740c7).
 
 - Total Issues: 5 (4 Fixed, 1 Acknowledged)
 - Critical Issues: 0

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ See [full report](Oxorio%20Lido%20Easy%20Track%20Smart%20Contracts%20Security%20
 
 Audited at commit [`ad6a9e8`](https://github.com/lidofinance/stonks/tree/ad6a9e83c095f5052e404bc13585ad2c752f242f).
 
-This audit report covers the code up to commit [`ad6a9e83c095f5052e404bc13585ad2c752f242f`](https://github.com/lidofinance/stonks/tree/ad6a9e83c095f5052e404bc13585ad2c752f242f). For release version audit please go to [03-2024 Ackee Blockchain Lido Stonks Audit](#03-2024-ackee-blockchain-lido-stonks-audit).
+This audit report covers the code up to the audited commit above. For release version audit please go to [03-2024 Ackee Blockchain Lido Stonks Audit](#03-2024-ackee-blockchain-lido-stonks-audit).
 
 - Total Issues: 8 (4 Fixed, 4 Acknowledged)
 - Critical: 0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ### 12-2020 Sigma Prime Security Assessment
 
+Audited at commit [`ad4b2f6`](https://github.com/lidofinance/lido-dao/tree/ad4b2f634850e46375bf5c8717abf0e49cdce3be).
+
 The testing team identified a total of eighteen (18) issues during this assessment, of which:
 
 - Five (5) are classified as medium risk (4 resolved, 1 closed),
@@ -13,6 +15,8 @@ The testing team identified a total of eighteen (18) issues during this assessme
 See [full report](Sigma%20Prime%20-%20Lido%20Finance%20Security%20Assessment%20Report%20v2.1.pdf) for more details.
 
 ### 12-2020 Quantstamp Audit
+
+Audited at commit [`ad4b2f6`](https://github.com/lidofinance/lido-dao/tree/ad4b2f634850e46375bf5c8717abf0e49cdce3be).
 
 - Total Issues: 14 (7 Resolved)
 - High Risk Issues: 0 (0 Resolved)
@@ -25,6 +29,8 @@ See [full report](QSP%20Lido%20Report%2012-2020.pdf) for more details.
 
 ### 04-2021 MixBytes Audit: ETH2 Oracle
 
+Audited at commit [`bea1be9`](https://github.com/lidofinance/lido-dao/tree/bea1be988a6f5db1dc2bd002ab5919b71e4ce796).
+
 - Total Issues: 7 (1 Fixed, 6 No issue)
 - Critical Issues: 0
 - Major Issues: 0
@@ -34,6 +40,8 @@ See [full report](QSP%20Lido%20Report%2012-2020.pdf) for more details.
 See [full report](MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021.pdf) for more details.
 
 ### 05-2021 MixBytes Audit: stETH price oracle
+
+Audited at commit [`1033b3e`](https://github.com/lidofinance/curve-merkle-oracle/tree/1033b3e84142317ffd8f366b52e489d5eb49c73f).
 
 - Total Issues: 7 (4 Fixed, 1 No issue, 2 Acknowledged)
 - Critical Issues: 0
@@ -45,6 +53,8 @@ See [full report](MixBytes%20stETH%20price%20oracle%20Security%20Audit%20Report%
 
 ### 05-2021 MixBytes Audit: Withdrawals Manager Proxy and Stub
 
+Audited at commit [`214d477`](https://github.com/lidofinance/withdrawals-manager-stub/tree/214d4773648134f970509bfe37184aee3aff4d24).
+
 - Total Issues: 1 (1 Fixed)
 - Critical Issues: 0
 - Major Issues: 0
@@ -54,6 +64,8 @@ See [full report](MixBytes%20stETH%20price%20oracle%20Security%20Audit%20Report%
 See [full report](MixBytes%20Withdrawals%20Manager%20Stub%20Security%20Audit%20Report%2005-2021.pdf) for more details.
 
 ### 06-2021 MixBytes stETH Price Feed Security Audit
+
+Audited at commit [`4a5db9a`](https://github.com/lidofinance/steth-price-feed/tree/4a5db9ad4b0c8d815388d087a023f2b390af351a).
 
 - Total Issues: 10 (3 Fixed, 6 No issue, 1 Acknowledged)
 - Critical Issues: 0
@@ -65,6 +77,8 @@ See [full report](MixBytes%20stETH%20Price%20Feed%20Security%20Audit%20Report%20
 
 ### 07-2021 MixBytes bETH Vault Security Audit
 
+Audited at commit [`c24beb0`](https://github.com/lidofinance/anchor-collateral-steth/tree/c24beb01afd7f6397e78062dd9a46906d38bc08b).
+
 - Total Issues: 5 (3 Fixed, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -74,6 +88,8 @@ See [full report](MixBytes%20stETH%20Price%20Feed%20Security%20Audit%20Report%20
 See [full report](MixBytes%20bETH%20Vault%20Security%20Audit%20Report%2007-2021.pdf) for more details.
 
 ### 08-2021 MixBytes bETH Vault Security Audit
+
+Audited at commit [`2fed0a0`](https://github.com/lidofinance/anchor-collateral-steth/tree/2fed0a0c0ba4ce67c82d0ed49cf6872245f44d20).
 
 bETH Vault was re-audited by MixBytes to incorporate the changes made since the previous audit.
 
@@ -87,6 +103,8 @@ See [full report](MixBytes%20bETH%20Vault%20Security%20Audit%20Report%2008-2021.
 
 ### 09-2021 MixBytes wstETH Security Audit
 
+Audited at commit [`ea6fa22`](https://github.com/lidofinance/lido-dao/tree/ea6fa222004b88e6a24b566a51e5b56b0079272d).
+
 - Total Issues: 5 (3 Acknowledged, 2 No Issue)
 - Critical Issues: 0
 - Major Issues: 0
@@ -96,6 +114,8 @@ See [full report](MixBytes%20bETH%20Vault%20Security%20Audit%20Report%2008-2021.
 See [full report](MixBytes%20wstETH%20Security%20Audit%20Report%2009-2021.pdf) for more details.
 
 ### 09-2021 MixBytes Easy Track Security Audit
+
+Audited at commit [`7acdfe0`](https://github.com/lidofinance/easy-track/tree/7acdfe0cc9d0f2fc34b03e094c8225c0c9c659a3).
 
 - Total Issues: 3 (2 Fixed, 1 No Issue)
 - Critical Issues: 0
@@ -107,6 +127,8 @@ See [full report](MixBytes%20Easy%20Track%20Security%20Audit%20Report%2009-2021.
 
 ### 09-2021 MixBytes 1inch Rewards Manager Security Audit
 
+Audited at commit [`c2cd966`](https://github.com/lidofinance/1inch-rewards-manager/tree/c2cd9665666deda9452fa9e3461fbf3537413945).
+
 - Total Issues: 4 (4 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -116,6 +138,8 @@ See [full report](MixBytes%20Easy%20Track%20Security%20Audit%20Report%2009-2021.
 See [full report](MixBytes%201inch%20Rewards%20Manager%20Security%20Audit%20Report%2009-21.pdf) for more details.
 
 ### 10-2021 MixBytes Aragon Voting Security Audit
+
+Audited at commit [`8c46da8`](https://github.com/lidofinance/aragon-apps/tree/8c46da8704d0011c42ece2896dbf4aeee069b84a).
 
 The version of the [Aragon Voting smart contract](https://github.com/lidofinance/aragon-apps/blob/8c46da8704d0011c42ece2896dbf4aeee069b84a/apps/voting/contracts/Voting.sol) with support of the voting time change.
 
@@ -129,6 +153,8 @@ See [full report](MixBytes%20Aragon%20Voting%20Security%20Audit%20Report%2010-20
 
 ### 10-2021 Sigma Prime Easy Track Smart Contract Security Review
 
+Audited at commit [`d7c0b24`](https://github.com/lidofinance/easy-track/tree/d7c0b24776c5d6c673236ac70a15c6d1c17d2520).
+
 The testing team identified a total of nine (9) issues during this assessment, of which:
 
 - One (1) is classified as high risk (1 resolved),
@@ -138,6 +164,8 @@ The testing team identified a total of nine (9) issues during this assessment, o
 See [full report](Sigma%20Prime%20-%20Lido%20Easy%20Track%20Smart%20Contract%20Security%20Review%20Report%20v2.0%2010-2021.pdf) for more details.
 
 ### 01-2022 MixBytes bETH Vault Security Audit Report
+
+Audited at commit [`9dd1e34`](https://github.com/lidofinance/anchor-collateral-steth/tree/9dd1e3433dd3d0360b95cf9470dd8af29dfce9e9).
 
 bETH Vault was re-audited by MixBytes to incorporate the changes made for the vault to work with Wormhole bridge instead of the Shuttle bridge.
 
@@ -151,6 +179,8 @@ See [full report](MixBytes%20bETH%20Vault%20Security%20Audit%20Report%2001-2022.
 
 ### 02-2022 MixBytes AAVE stETH integration Security Audit Report
 
+Audited at commit [`2a42cb5`](https://github.com/lidofinance/aave-protocol-v2/tree/2a42cb58d49c350d72c87614f0cf86819b29daa3).
+
 - Total Issues: 11 (3 Fixed, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 1 (1 Fixed)
@@ -160,6 +190,8 @@ See [full report](MixBytes%20bETH%20Vault%20Security%20Audit%20Report%2001-2022.
 See [full report](MixBytes%20AAVE%20stETH%20integration%20Security%20Audit%20Report%2002-22.pdf) for more details.
 
 ### 02-2022 MixBytes In-protocol Coverage Security Audit Report
+
+Audited at commit [`3d6a3f5`](https://github.com/lidofinance/lido-dao/tree/3d6a3f527e27a87e33c97726cce7de1ae7262d9f).
 
 - Total Issues: 3 (3 Fixed)
 - Critical Issues: 1 (1 Fixed)
@@ -171,6 +203,8 @@ See [full report](MixBytes%20In-protocol%20Coverage%20Security%20Audit%20Report%
 
 ### 02-2022 MixBytes Deposit Security Module Security Audit Report
 
+Audited at commit [`816bf1d`](https://github.com/lidofinance/lido-dao/tree/816bf1d0995ba5cfdfc264de4acda34a7fe93eba).
+
 - Total Issues: 22 (17 Fixed, 5 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 2 (2 Fixed)
@@ -180,6 +214,8 @@ See [full report](MixBytes%20In-protocol%20Coverage%20Security%20Audit%20Report%
 See [full report](MixBytes%20Deposit%20Security%20Module%20Security%20Audit%20Report%2002-2022.pdf) for more details.
 
 ### 05-2022 Oxorio Jumpgate Smart Contracts Security Audit Report
+
+Audited at commit [`0802ae1`](https://github.com/lidofinance/jumpgates/tree/0802ae168c81c9a4aa32a1b3f1ac0099cd090428).
 
 - Total Issues: 12 (11 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -191,6 +227,8 @@ See [full report](Oxorio%20Jumpgate%20Smart%20Contracts%20Security%20Audit%20Rep
 
 ### 05-2022 MixBytes Lido Protocol Security Audit Report
 
+Audited at commit [`08436ce`](https://github.com/lidofinance/lido-dao/tree/08436ce13d67501fa723169c1dc69fe47b90cde4).
+
 - Total Issues: 15 (13 Fixed, 2 Acknowledged)
 - Critical Issues: 0
 - High Issues: 1 (1 Fixed)
@@ -201,6 +239,8 @@ See [full report](MixBytes%20Lido_Protocol_Security_Audit_Report%2005-2022.pdf) 
 
 ### 06-2022 MixBytes Lido Two-Phase Voting Security Audit Report
 
+Audited at commit [`4f7646f`](https://github.com/lidofinance/aragon-apps/tree/4f7646fbc90ac31fada5ed9e95669fc4aecbbc1c).
+
 - Total Issues: 10 (7 Fixed, 3 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -210,6 +250,8 @@ See [full report](MixBytes%20Lido_Protocol_Security_Audit_Report%2005-2022.pdf) 
 See [full report](MixBytes%20Lido%20Two-Phase%20Voting%20Security%20Audit%20Report%2006-2022.pdf) for more details.
 
 ### 08-2022 ChainSecurity Code Assessment of the Lido Smart Contracts Audit Report
+
+Audited at commit [`08436ce`](https://github.com/lidofinance/lido-dao/tree/08436ce13d67501fa723169c1dc69fe47b90cde4).
 
 - Total Issues: 9 (4 Risk accepted, 5 Acknowledged)
 - Critical Issues: 0
@@ -222,9 +264,13 @@ See [full report](ChainSecurity%20Code%20Assessment%20of%20the%20Lido%20Smart%20
 
 ### 08-2022 MixBytes Lido Protocol Security Auditor's Note On The Deployed Code Compliance
 
+Audited at commit [`08436ce`](https://github.com/lidofinance/lido-dao/tree/08436ce13d67501fa723169c1dc69fe47b90cde4).
+
 See [note](MixBytes%20Note%20on%20Deployed%20Code%20Compliance%2008-22.pdf) contents for more details.
 
 ### 09-2022 Statemind MEV-Boost relay allowlist Security Audit Report
+
+Audited at commit [`912f414`](https://github.com/lidofinance/mev-boost-relay-allowed-list/tree/912f4143387ab04a7042b4887df67d3eecc97179).
 
 - Total Issues: 7 (5 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -236,6 +282,8 @@ See [full report](Statemind%20MEV-Boost%20relay%20allowlist%20Security%20Audit%2
 
 ### 09-2022 Statemind Insurance Fund Audit Report
 
+Audited at commit [`625d384`](https://github.com/lidofinance/insurance-fund/tree/625d384f12c3df791085ecc2d15535e2121224d5).
+
 - Total Issues: 4 (1 Fixed, 3 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -245,6 +293,8 @@ See [full report](Statemind%20MEV-Boost%20relay%20allowlist%20Security%20Audit%2
 See [full report](Statemind%20Insurance%20Fund%20Audit%20Report%2009-2022.pdf) for more details.
 
 ### 09-2022 Statemind Easy Track Payment Processor with limits
+
+Audited at commit [`cf5e788`](https://github.com/lidofinance/easy-track/tree/cf5e7887b60a3043f92f6cc0c25b5b4034431556).
 
 - Total Issues: 9 (9 Acknowledged)
 - Critical Issues: 0
@@ -256,6 +306,8 @@ See [full report](Statemind%20Easy%20Track%20Payment%20Processor%20with%20limits
 
 ### 01-2023 Statemind TRP Vesting Escrow Audit Report
 
+Audited at commit [`69dd13a`](https://github.com/lidofinance/lido-vesting-escrow/tree/69dd13adcd9c5a88da8c134b221209ccded04121).
+
 - Total Issues: 5 (4 Fixed, 1 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -266,6 +318,8 @@ See [full report](Statemind%20TRP%20Vesting%20Escrow%20Audit%20Report%2001-2023.
 
 ### 02-2023 ChainSecurity Lido Staking Router Audit Report
 
+Audited at commit [`d820fdd`](https://github.com/lidofinance/lido-dao/tree/d820fddb0b298088db2a4d76fbc6007fdada908d).
+
 - Total Issues: 13 (10 Fixed, 3 Acknowledged)
 - Critical Issues: 0
 - High Issues: 1 (1 Fixed)
@@ -275,6 +329,8 @@ See [full report](Statemind%20TRP%20Vesting%20Escrow%20Audit%20Report%2001-2023.
 See [full report](ChainSecurity%20Lido%20Staking%20Router%20audit%20report%2002-23.pdf) for more details.
 
 ### 03-2023 Sigma Prime dc4bc Security Audit
+
+Audited at commit [`3f2e02a`](https://github.com/lidofinance/dc4bc/tree/3f2e02a).
 
 - Total Issues: 8 (8 Fixed)
 - Critical Issues: 0
@@ -287,6 +343,8 @@ See [full report](Sigma%20Prime%20-%20Lido%20-%20dc4bc%20Security%20Assessment%2
 
 ### 04-2023 Hexens Lido V2 Smart Contract Audit
 
+Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4d6fb8120fd29426b8d969c19d8a798ca974).
+
 - Total Issues: 25 (16 Fixed, 9 Acknowledged)
 - Critical Issues: 1 (1 Fixed)
 - High Issues: 3 (3 Fixed)
@@ -298,6 +356,8 @@ See [full report](Hexens%20Lido%20V2%20Smart%20Contract%20Audit%20Report%2004-23
 
 ### 04-2023 MixBytes Camp Lido V2 Contest
 
+Audited at commit [`e575177`](https://github.com/lidofinance/lido-dao/tree/e57517730c3e11a41e9cbc32ce018726722335b7).
+
 - Total Issues: 17 (8 Fixed, 9 Acknowledged)
 - Critical Issues: 0
 - High Issues: 1 (1 Acknowledged)
@@ -307,6 +367,8 @@ See [full report](Hexens%20Lido%20V2%20Smart%20Contract%20Audit%20Report%2004-23
 See [full report](MixBytes%20Camp%20Lido%20V2%20Contest%20Report%2004-23.pdf) for more details.
 
 ### 04-2023 Statemind GateSeals Audit
+
+Audited at commit [`7e9704d`](https://github.com/lidofinance/gate-seals/tree/7e9704d9f40cd17652480a15f2ca9519d6b532d2).
 
 - Total Issues: 4 (3 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -319,6 +381,8 @@ See [full report](Statemind%20GateSeals%20Audit%20Report%2004-2023.pdf) for more
 
 ### 04-2023 Certora Lido V2 Audit
 
+Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4d6fb8120fd29426b8d969c19d8a798ca974).
+
 - Total Issues: 23 (14 Fixed, 9 Acknowledged)
 - Critical Issues: 2 (2 Fixed)
 - High Issues: 5 (1 Fixed, 4 Acknowledged)
@@ -330,6 +394,8 @@ See [full report](Certora%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more det
 
 ### 04-2023 Statemind Lido V2 Audit
 
+Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4d6fb8120fd29426b8d969c19d8a798ca974).
+
 - Total Issues: 120 (75 Fixed, 45 Acknowledged)
 - Critical Issues: 2 (1 Fixed, 1 Acknowledged)
 - High Issues: 8 (6 Fixed, 2 Acknowledged)
@@ -339,6 +405,8 @@ See [full report](Certora%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more det
 See [full report](Statemind%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more details.
 
 ### 05-2023 Statemind Lido V2 Upgrade Template Audit
+
+Audited at commit [`a19c6b7`](https://github.com/lidofinance/lido-dao/tree/a19c6b7e2d661de12e2ba585c251c8d70a1da230).
 
 - Total Issues: 14 (7 Fixed, 7 Acknowledged)
 - Critical Issues: 0
@@ -350,9 +418,13 @@ See [full report](Statemind%20Lido%20V2%20Upgrade%20Template%20Audit%20Report%20
 
 ### 05-2023 Statemind Lido V2 Deployment Validation Note
 
+Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4d6fb8120fd29426b8d969c19d8a798ca974).
+
 See [note](Statemind%20Lido%20V2%20Deployment%20Validation%2005-2023.pdf) contents for more details.
 
 ### 05-2023 Hexens Lido V2 Oracle Security Review
+
+Audited at commit [`4467895`](https://github.com/lidofinance/lido-oracle/tree/44678954915b8291c949904c63de5e4e4983b427).
 
 - Total Issues: 2 (2 Fixed)
 - Critical Issues: 0
@@ -365,6 +437,8 @@ See [full report](Hexens%20Lido%20V2%20Oracle%20Security%20Review%20Report%2005-
 
 ### 05-2023 Oxorio Lido V2 On-chain Audit
 
+Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4d6fb8120fd29426b8d969c19d8a798ca974).
+
 - Total Issues: 43 (4 Fixed, 37 Acknowledged, 2 No Issue)
 - Critical: 0
 - Major: 7 (7 Acknowledged)
@@ -374,6 +448,8 @@ See [full report](Hexens%20Lido%20V2%20Oracle%20Security%20Review%20Report%2005-
 See [full report](Oxorio%20Lido%20V2%20On-chain%20Audit%20Report%2006-23.pdf) for more details.
 
 ### 05-2023 Oxorio Lido V2 Off-chain Audit
+
+Audited at commit [`4467895`](https://github.com/lidofinance/lido-oracle/tree/44678954915b8291c949904c63de5e4e4983b427).
 
 - Total Issues: 11 (1 Fixed, 10 Acknowledged)
 - Critical: 0
@@ -397,6 +473,8 @@ See [full report](Statemind%20Lido%20roles%20analysis%2010-2023.pdf) for more de
 
 ### 10-2023 Oxorio Lido Easy Track Smart Contracts Security Audit (Easy Track Factories for Stablecoins)
 
+Audited at commit [`425f4a2`](https://github.com/lidofinance/easy-track/tree/425f4a254ceb2be389f669580b9dc76618e92756).
+
 - Total Issues: 9 (5 Fixed, 4 Acknowledged)
 - Critical: 0
 - Major: 0
@@ -406,6 +484,8 @@ See [full report](Statemind%20Lido%20roles%20analysis%2010-2023.pdf) for more de
 See [full report](Oxorio%20Lido%20Easy%20Track%20Smart%20Contracts%20Security%20Audit%20Report%2010-2023.pdf) for more details.
 
 ### 12-2023 Pessimistic Lido Stonks Audit
+
+Audited at commit [`ad6a9e8`](https://github.com/lidofinance/stonks/tree/ad6a9e83c095f5052e404bc13585ad2c752f242f).
 
 This audit report covers the code up to commit [`ad6a9e83c095f5052e404bc13585ad2c752f242f`](https://github.com/lidofinance/stonks/tree/ad6a9e83c095f5052e404bc13585ad2c752f242f). For release version audit please go to [03-2024 Ackee Blockchain Lido Stonks Audit](#03-2024-ackee-blockchain-lido-stonks-audit).
 
@@ -419,6 +499,8 @@ See [full report](Pessimistic%20Lido%20Stonks%20Audit%20Report%2012-23.pdf) for 
 
 ### 01-2024 Statemind Lido Simple DVT Easy Track Factories Audit
 
+Audited at commit [`bccc999`](https://github.com/lidofinance/easy-track/tree/bccc99912b8cd03cb152ebc13295cc3a3ea28664).
+
 - Total Issues: 10 (7 Fixed, 3 Acknowledged)
 - Critical: 0
 - High: 0
@@ -428,6 +510,8 @@ See [full report](Pessimistic%20Lido%20Stonks%20Audit%20Report%2012-23.pdf) for 
 See [full report](Statemind%20Lido%20Simple%20DVT%20Easy%20Track%20Factories%20Audit%20Report%2001-24.pdf) for more details.
 
 ### 03-2024 Ackee Blockchain Lido Stonks Audit
+
+Audited at commit [`40af0bb`](https://github.com/lidofinance/stonks/tree/40af0bb3ede47b7666d402280b96f05e6c897546).
 
 - Total Issues: 9 (7 Fixed, 2 Acknowledged)
 - Critical: 0
@@ -440,9 +524,13 @@ See [full report](Ackee%20Blockchain%20Lido%20Stonks%20Audit%20Report%2003-24.pd
 
 ### 04-2024 Statemind GateSeal Deployment Validation Note
 
+Audited at commit [`7e9704d`](https://github.com/lidofinance/gate-seals/tree/7e9704d9f40cd17652480a15f2ca9519d6b532d2).
+
 See [note](Statemind%20GateSeal%20Deployment%20Validation%2004-2024.pdf) contents for more details.
 
 ### 06-2024 ChainSecurity Code Assessment of the LIP-23: Rebase Check Smart Contracts
+
+Audited at commit [`efeff81`](https://github.com/lidofinance/lido-dao/tree/efeff81c18f85451ebf98e8fd8bb78b8eb0095f6).
 
 - Total Issues: 3 (3 Fixed)
 - Critical Issues: 0
@@ -455,6 +543,8 @@ See [full report](ChainSecurity%20Code%20Assessment%20of%20LIP-23%20Negative%20R
 
 ### 07-2024 Ackee Blockchain Audit of the Simple Delegation
 
+Audited at commit [`50d9802`](https://github.com/lidofinance/aragon-apps/tree/50d9802f6e728388b80b275b7baea5d93b9b6b25).
+
 - Total Issues: 14 (6 Fixed, 8 Acknowledged)
 - High Issues: 0
 - Medium Issues: 0
@@ -464,6 +554,8 @@ See [full report](ChainSecurity%20Code%20Assessment%20of%20LIP-23%20Negative%20R
 See [full report](Ackee%20Blockchain%20Lido%20Simple%20Delegation%20audit%20report%2007-24.pdf) for more details.
 
 ### 07-2024 Statemind Audit of the Simple Delegation
+
+Audited at commit [`50d9802`](https://github.com/lidofinance/aragon-apps/tree/50d9802f6e728388b80b275b7baea5d93b9b6b25).
 
 - Total Issues: 6 (2 Fixed, 4 Acknowledged)
 - Critical Issues: 0
@@ -475,6 +567,8 @@ See [full report](Statemind%20Lido%20Simple%20Delegation%20audit%20report%2007-2
 
 ### 07-2024 MixBytes Sanity Checker Security Audit (LIP-23)
 
+Audited at commit [`f6deb4b`](https://github.com/lidofinance/core/tree/f6deb4bcd4f1a05a7336111c0a139fcebcae6b68).
+
 - Total Issues: 8 (4 Fixed, 4 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -484,6 +578,8 @@ See [full report](Statemind%20Lido%20Simple%20Delegation%20audit%20report%2007-2
 See [full report](Lido%20Sanity%20Checker%20Security%20Audit%20Report.pdf) for more details.
 
 ### 10-2024 Ackee Blockchain Audit of Staking Router v2 (LIP-25)
+
+Audited at commit [`1ffbb7e`](https://github.com/lidofinance/core/tree/1ffbb7e49e112fcac678f59bf63ba57a7e522874).
 
 - Total Issues: 7 (5 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -497,6 +593,8 @@ See [full report](Ackee%20Blockchain%20Lido%20Staking%20Router%20v2%20Report%201
 
 ### 10-2024 Ackee Blockchain Audit of Community Staking Module (LIP-26)
 
+Audited at commit [`347496d`](https://github.com/lidofinance/community-staking-module/tree/347496df916c3b987a7f3fe8b0bd85c9b62ad730).
+
 - Total Issues: 39 (25 Fixed, 2 Partially fixed, 12 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -509,6 +607,8 @@ See [full report](Ackee%20Blockchain%20Lido%20Community%20Staking%20Module%20Rep
 
 ### 10-2024 MixBytes On-chain Audit of Community Staking Module (LIP-23, LIP-25, LIP-26)
 
+Audited at commit [`9c7d014`](https://github.com/lidofinance/community-staking-module/tree/9c7d014844395b37a64b3ca4ed5dc27de0af23a5).
+
 - Total Issues: 41 (18 Fixed, 23 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -518,6 +618,8 @@ See [full report](Ackee%20Blockchain%20Lido%20Community%20Staking%20Module%20Rep
 See [full report](MixBytes%20Lido%20CSM%20Security%20Audit%20Report%2010-24.pdf) for more details.
 
 ### 10-2024 MixBytes Off-chain Audit of Lido Oracle v4
+
+Audited at commit [`e363fe4`](https://github.com/lidofinance/lido-oracle/tree/e363fe41fa771ebbc54bb33395222a5f5c8855ad).
 
 - Total Issues: 3 (2 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -529,9 +631,13 @@ See [full report](MixBytes%20Lido%20Oracle%20Security%20Audit%20Report%2010-24.p
 
 ### 03-2025 Statemind GateSeal Deployment Validation Note
 
+Audited at commit [`7e9704d`](https://github.com/lidofinance/gate-seals/tree/7e9704d9f40cd17652480a15f2ca9519d6b532d2).
+
 See [note](Statemind%20GateSeal%20Deployment%20Validation%2003-2025.pdf) contents for more details.
 
 ### 09-2024 Certora Dual Governance Draft Audit
+
+Audited at commit [`071f033`](https://github.com/lidofinance/dual-governance/tree/071f0338c05f3809ac3ebf90b58f2c21d718177f).
 
 - Total Issues: 23 (22 Fixed, 1 Acknowledged)
 - Critical Issues: 2 (2 Fixed)
@@ -543,6 +649,8 @@ See full [report](Certora%20Dual%20Governance%20Draft%20Audit%20Report%2009-2024
 
 ### 02-2025 Certora Dual Governance Audit
 
+Audited at commit [`3e0f1ae`](https://github.com/lidofinance/dual-governance/tree/3e0f1ae5740ef8410e928f6cc106e3a5f45a5a75).
+
 - Total Issues: 6 (4 Fixed, 2 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -553,10 +661,14 @@ See full [report](Certora%20Dual%20Governance%20Audit%20Report%2002-2025.pdf) fo
 
 ### 08-2025 Certora Dual Governance v.1.0.1 Hotfix Review
 
+Audited at commit [`0d31f5b`](https://github.com/lidofinance/dual-governance/tree/0d31f5b3dbe0a553887604a2d5755d14033b8e3d).
+
 Lido has engaged Certora to review and verify the correctness and safety of the Dual Governance v.1.0.1 hotfix.
 See full [report](Certora%20Dual%20Governance%20v1.0.1%20Hotfix%20Review%20Report%2008-2025.pdf) for more details.
 
 ### 10-2024 Statemind Dual Governance Audit
+
+Audited at commit [`3e0f1ae`](https://github.com/lidofinance/dual-governance/tree/3e0f1ae5740ef8410e928f6cc106e3a5f45a5a75).
 
 - Total Issues: 46 (32 Fixed, 14 Acknowledged)
 - Critical Issues: 0
@@ -568,13 +680,19 @@ See full [report](Statemind%20Dual%20Governance%20Audit%20Report%2010-2024.pdf) 
 
 ### 06-2025 Statemind Dual Governance Deployment and Voting Script Review
 
+Audited at commit [`7480c3c`](https://github.com/lidofinance/dual-governance/tree/7480c3cdc813312c0c36d6faf0f7e6e4148ebfb2).
+
 See [note](Statemind%20Dual%20Governance%20Deployment%20and%20Voting%20Script%20Review%20Report%2006-2025.pdf) contents for more details.
 
 ### 08-2025 Statemind Dual Governance Escrow Fix Review and Deployment Validation
 
+Audited at commit [`8c77d57`](https://github.com/lidofinance/dual-governance/tree/8c77d57a4c415bb69c6873d174be7c30b1103907).
+
 See [note](Statemind%20Dual%20Governance%20Escrow%20Fix%20Review%20Report%2008-2025.pdf) contents for more details.
 
 ### 11-2024 OpenZeppelin Dual Governance Audit
+
+Audited at commit [`8296824`](https://github.com/lidofinance/dual-governance/tree/8296824213195dd5421222602cbeb3f5a25017b2).
 
 - Total Issues: 26 (18 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -587,6 +705,8 @@ See full [report](OpenZeppelin%20Dual%20Governance%20Audit%20Report%2011-2024.pd
 
 ### 02-2025 OpenZeppelin Dual Governance Re-Audit
 
+Audited at commit [`3e0f1ae`](https://github.com/lidofinance/dual-governance/tree/3e0f1ae5740ef8410e928f6cc106e3a5f45a5a75).
+
 - Total Issues: 9 (4 Fixed, 2 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -598,11 +718,15 @@ See full [report](OpenZeppelin%20Dual%20Governance%20Re-Audit%20Report%2002-2025
 
 ### 02-2025 Runtime Verification Dual Governance Formal Verification
 
+Audited at commit [`3e0f1ae`](https://github.com/lidofinance/dual-governance/tree/3e0f1ae5740ef8410e928f6cc106e3a5f45a5a75).
+
 Lido has engaged Runtime Verification to formally verify the correctness and safety properties of the smart contracts that comprise the Lido Dual Governance mechanism.
 
 See full [report](Runtime%20Verification%20Dual%20Governance%20Formal%20Verification%20Report%2002-2025.pdf) for more details.
 
 ### 04-2025 MixBytes Off-chain Audit of Lido Oracle v5
+
+Audited at commit [`41f3f96`](https://github.com/lidofinance/lido-oracle/tree/41f3f9671ea7e349e048c3ac47264a118c7983a8).
 
 - Total Issues: 6 (5 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -613,6 +737,8 @@ See full [report](Runtime%20Verification%20Dual%20Governance%20Formal%20Verifica
 See [full report](MixBytes%20Lido%20Oracle%20v5%2004-25.pdf) for more details.
 
 ### 04-2025 Composable Security Off-chain Audit of Lido Oracle v5
+
+Audited at commit [`41f3f96`](https://github.com/lidofinance/lido-oracle/tree/41f3f9671ea7e349e048c3ac47264a118c7983a8).
 
 - Total Issues: 6 (4 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -625,11 +751,15 @@ See [full report](Composable%20Security%20Lido%20Oracle%20v5%2004-25.pdf) for mo
 
 ### 08-2025 Composable Security Off-chain Audit of Lido Oracle v5.4.1
 
+Audited at commit [`f17f089`](https://github.com/lidofinance/lido-oracle/tree/f17f0898cd8c46eefba5da0ad3162dc2f4bcf439).
+
 A security audit for a hotfix to the Lido Oracle V5. Previous [report for V5](#04-2025-composable-security-off-chain-audit-of-lido-oracle-v5).
 
 See [full report](Composable%20Security%20Lido%20Oracle%20V5_4_1%2008-25.pdf) for more details.
 
 ### 04-2025 Ackee Blockchain Audit of Community Staking Module (LIP-26, LIP-27)
+
+Audited at commit [`3469910`](https://github.com/lidofinance/community-staking-module/tree/3469910c0d29a54b37d0c4de3cf527a3e7be2099).
 
 An updated report for [the previously audited Lido Community Staking Module](#10-2024-ackee-blockchain-audit-of-community-staking-module-lip-26) features a re-audit of the revised CS Verifier contract and deployment verification for the redeployed contract. This contract was updated to reflect changes introduced in LIP-27.
 
@@ -639,6 +769,8 @@ See [full report](Ackee%20Blockchain%20Lido%20Community%20Staking%20Module%20Rep
 
 ### 07-2025 MixBytes On-chain Audit of Community Staking Module (LIP-23, LIP-25, LIP-26, LIP-27)
 
+Audited at commit [`d29a0bf`](https://github.com/lidofinance/community-staking-module/tree/d29a0bf4dac8d78550016beb82dbf16431db5ced).
+
 An updated report for [the previously audited Lido Community Staking Module](#10-2024-mixbytes-on-chain-audit-of-community-staking-module-lip-23-lip-25-lip-26) features a re-audit of the revised CS Verifier contract and deployment verification for the redeployed contract. This contract was updated to reflect changes introduced in LIP-27.
 
 No additional issues were found.
@@ -647,11 +779,15 @@ See [full report](MixBytes%20Lido%20CSM%20Security%20Audit%20Report%2007-2025.pd
 
 ### 05-2025 MixBytes Lido RMC EasyTrack Security Audit
 
+Audited at commit [`96606b6`](https://github.com/lidofinance/easy-track/tree/96606b69371268e5e3db3175bd1004d55c033a31).
+
 - Total Issues: 0
 
 See [full report](MixBytes%20Lido%20RMC%20EasyTrack%20Security%20Audit%20Report%2005-2025.pdf) for more details.
 
 ### 09-2025 MixBytes Lido Triggerable Withdrawals Easy Track Security Audit
+
+Audited at commit [`a4bbe78`](https://github.com/lidofinance/easy-track/tree/a4bbe78934bdec534c4b78871f0bdce57467eab1).
 
 - Total Issues: 3
 - Low Issues: 3 (3 Fixed)
@@ -660,11 +796,15 @@ See [full report](MixBytes%20Lido%20Easy%20Track%20Security%20Audit%20Report%200
 
 ### 06-2025 Composable Security Lido Oracle v5.2 Security Consultation
 
+Audited at commit [`701306d`](https://github.com/lidofinance/lido-oracle/tree/701306dfba316ea4b8b3c0714a7297dc9ce6594b).
+
 After conducting a consultation, the security assessment did not identify any vulnerabilities introduced by the introduced version that could directly compromise the security or operational integrity of the Oracle system.
 
 See [full report](Composable%20Security%20Lido%20Oracle%20V5_2%2006-25.pdf) for more details.
 
 ### 07-2025 Nethermind Lido Accounting Zk Oracle Security Review
+
+Audited at commit [`06bb68a`](https://github.com/lidofinance/sp1-lido-accounting-zk/tree/06bb68acdc86b3722ccb4be726f271a7f26a3b59).
 
 - Total Issues: 9 (8 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -678,6 +818,8 @@ See [full report](zk/Nethermind_LIDO_ACCOUNTING_ZK_ORACLE_FINAL.pdf) for more de
 
 ### 08-2025 Code4rena Audit of Lido Community Staking Module
 
+Audited at commit [`d63d123`](https://github.com/lidofinance/community-staking-module/tree/d63d123f24e2ed2fb2f039238e7562a3d61532b2).
+
 - Total Issues: 2 (2 Acknowledged)
 - Low Issues: 2 (2 Acknowledged)
 
@@ -685,11 +827,15 @@ See [full report](Code4rena%20CSM%20V2%20Audit%20Report%2008-2025.pdf) for more 
 
 ### 09-2025 MixBytes WstETH Staker Security Audit
 
+Audited at commit [`97e0f16`](https://github.com/lidofinance/si-lidity/tree/97e0f166baf638e082a2dcf72fe2ec3ba73e5ddb).
+
 - Total Issues: 0
 
 See [full report](MixBytes%20WstETH%20Staker%20Security%20Audit%20Report%2009-2025.pdf) for more details.
 
 ### 09-2025 Ackee Blockchain Lido Triggerable Withdrawals Security Audit
+
+Audited at commit [`acf3188`](https://github.com/lidofinance/core/tree/acf3188c79e5616ef7594999f606473214e10f6b).
 
 - Total Issues: 11 (9 Fixed, 1 Partially fixed, 1 Acknowledged)
 - Low Issues: 2 (2 Fixed)
@@ -699,6 +845,8 @@ See [full report](MixBytes%20WstETH%20Staker%20Security%20Audit%20Report%2009-20
 See [full report](Ackee%20Blockchain%20Lido%20Triggerable%20Withdrawals%20Audit%20Report%2009-25.pdf) for more details.
 
 ### 09-2025 Composable Security Lido Oracle v6 Security Audit
+
+Audited at commit [`ec19c76`](https://github.com/lidofinance/lido-oracle/tree/ec19c76b5511ec48f0cfa51b9f216240e9373471).
 
 - Total Issues: 4 (2 Fixed, 2 Acknowledged)
 - Low Issues: 2 (2 Acknowledged)
@@ -712,11 +860,15 @@ See [full report](Composable%20Security%20Lido%20Oracle%20V6_0_2%20Audit%20Repor
 
 ### 09-2025 MixBytes Easy Track CSM v2 Security Audit
 
+Audited at commit [`12cd20d`](https://github.com/lidofinance/easy-track/tree/12cd20d95272a73338a084bb4a40a6fd8c3ec472).
+
 - Total Issues: 0
 
 See [full report](MixBytes%20Easy%20Track%20CSM%20v2%20Security%20Audit%20Report%2009-2025.pdf) for more details.
 
 ### 09-2025 Ackee Blockchain CSM v2 Security Audit
+
+Audited at commit [`0e4b562`](https://github.com/lidofinance/community-staking-module/tree/0e4b562719cca51070c9cede5e5a8505eca18684).
 
 - Total Issues: 20 (10 Fixed, 10 Acknowledged)
 - High Issues: 2 (2 Fixed)
@@ -729,6 +881,8 @@ See [full report](Ackee%20Blockchain%20Community%20Staking%20Module%20v2%20Audit
 
 ### 09-2025 Statemind Triggerable Withdrawals and CSM v2 Audit
 
+Audited at commit [`0e4b562`](https://github.com/lidofinance/community-staking-module/tree/0e4b562719cca51070c9cede5e5a8505eca18684).
+
 - Total Issues: 26 (17 Fixed, 9 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -738,6 +892,8 @@ See [full report](Ackee%20Blockchain%20Community%20Staking%20Module%20v2%20Audit
 See [full report](Statemind%20Triggerable%20Withdrawals%20and%20CSM%20v2%20Audit%20Report%2009-2025.pdf) for more details.
 
 ### 12-2025 Certora Lido V3 Security Audit
+
+Audited at commit [`33f2f59`](https://github.com/lidofinance/core/tree/33f2f59156697aae93cdea2d0984de7be347e3af).
 
 - Total Issues: 84 (70 Fixed, 14 Acknowledged)
 - Critical Issues: 7 (7 Fixed)
@@ -750,6 +906,8 @@ See [full report](Certora%20Lido%20V3%20Audit%20Report%20-%2012-2025.pdf) for mo
 
 ### 12-2025 Certora Lido V3 Formal Verification
 
+Audited at commit [`b983714`](https://github.com/lidofinance/core/tree/b98371488eb9479cf072bd6c2b682a59c5dd71d8).
+
 - Total Issues: 10 (6 Fixed, 4 Acknowledged)
 - Critical Issues: 1 (1 Fixed)
 - High Issues: 0
@@ -760,6 +918,8 @@ See [full report](Certora%20Lido%20V3%20Audit%20Report%20-%2012-2025.pdf) for mo
 See [full report](Certora%20Lido%20V3%20Formal%20Verification%20Report%20-%2012-2025.pdf) for more details.
 
 ### 12-2025 Certora Lido V3 Oracle Off-chain Security Assessment
+
+Audited at commit [`39a1c5b`](https://github.com/lidofinance/lido-oracle/tree/39a1c5b8a5e1a90debb2f9eebac6e6588767a473).
 
 - Total Issues: 16 (7 Fixed, 9 Acknowledged)
 - Critical Issues: 0
@@ -772,6 +932,8 @@ See [full report](Certora%20Lido%20V3%20Oracle%20V7%20Audit%20Report%20-%2012-20
 
 ### 12-2025 MixBytes Lido V3 Security Audit
 
+Audited at commit [`33f2f59`](https://github.com/lidofinance/core/tree/33f2f59156697aae93cdea2d0984de7be347e3af).
+
 - Total Issues: 19 (8 Fixed, 11 Acknowledged)
 - Critical Issues: 0
 - High Issues: 1 (1 Acknowledged)
@@ -781,6 +943,8 @@ See [full report](Certora%20Lido%20V3%20Oracle%20V7%20Audit%20Report%20-%2012-20
 See [full report](MixBytes%20Lido%20V3%20Security%20Audit%20Report%20-%2012-2025.pdf) for more details. The report has been updated on 01-2026 with the latest commit taking into account the changes made to the BLS library.
 
 ### 12-2025 MixBytes Lido V3 Easy Track Security Audit
+
+Audited at commit [`aa2f545`](https://github.com/lidofinance/easy-track/tree/aa2f5456962dbd8f8599d1450fd8a576b84ade34).
 
 - Total Issues: 4 (2 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -792,6 +956,8 @@ See [full report](MixBytes%20Lido%20V3%20Easy%20Track%20Security%20Audit%20Repor
 
 ### 12-2025 Consensys Diligence Lido V3 Security Audit
 
+Audited at commit [`33f2f59`](https://github.com/lidofinance/core/tree/33f2f59156697aae93cdea2d0984de7be347e3af).
+
 - Total Issues: 43 (32 Fixed, 11 Acknowledged)
 - Critical Issues: 2 (2 Fixed)
 - Major Issues: 5 (5 Fixed)
@@ -802,6 +968,8 @@ See [full report](MixBytes%20Lido%20V3%20Easy%20Track%20Security%20Audit%20Repor
 See [full report](Consensys%20Diligence%20Lido%20V3%20Security%20Audit%20-%2011-2025.pdf) for more details. The report has been updated on 01-2026 with the latest commit taking into account the changes made to the BLS library.
 
 ### 12-2025 Ackee Blockchain Stonks 2.0 Audit
+
+Audited at commit [`0669c4a`](https://github.com/lidofinance/stonks/tree/0669c4a50660912785e18861d9ef8108a86a3552).
 
 - Total Issues: 17 (17 Fixed)
 - Critical Issues: 0
@@ -815,6 +983,8 @@ See [full report](Ackee%20Blockchain%20Stonks%202%20Audit%20Report%2012-25.pdf) 
 
 ### 12-2025 MixBytes Lido LDO Revesting Security Audit Report
 
+Audited at commit [`6d7e4cb`](https://github.com/lidofinance/ldo-revesting/tree/6d7e4cb9e971dc4006927ac9ba5447254f9db7a8).
+
 - Total Issues: 1 (1 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -824,6 +994,8 @@ See [full report](Ackee%20Blockchain%20Stonks%202%20Audit%20Report%2012-25.pdf) 
 See [full report](Lido%20LDO%20Revesting%20Security%20Audit%20Report%20-%2012-2025.pdf) for more details.
 
 ### 12-2025 Composable Security Lido Oracle v7 Security Audit
+
+Audited at commit [`39a1c5b`](https://github.com/lidofinance/lido-oracle/tree/39a1c5b8a5e1a90debb2f9eebac6e6588767a473).
 
 - Total Issues: 6 (4 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -836,6 +1008,8 @@ See [full report](Composable%20Security%20Lido%20V3%20Oracle%20V7%20Audit%20Repo
 
 ### 01-2026 Sigma Prime Lido BLS Library Security Audit
 
+Audited at commit [`33f2f59`](https://github.com/lidofinance/core/tree/33f2f59156697aae93cdea2d0984de7be347e3af).
+
 - Total Issues: 6 (6 Fixed)
 - Critical Issues: 0
 - High Issues: 0
@@ -847,6 +1021,8 @@ See [full report](Sigma%20Prime%20-%20Lido%20BLS%20Library%20Security%20Assessme
 
 ### 01-2026 MixBytes CSM Performance Oracle Security Audit
 
+Audited at commit [`2981a28`](https://github.com/lidofinance/community-staking-module/tree/2981a28d5573266abe98097f44f9cdc086944c4b).
+
 - Total Issues: 1 (1 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -857,6 +1033,8 @@ See [full report](MixBytes%20CSM%20Performance%20Oracle%20Security%20Audit%20Rep
 
 ### 01-2026 MixBytes Lido DeFi Wrapper Security Audit Report
 
+Audited at commit [`f35fe13`](https://github.com/lidofinance/vaults-wrapper/tree/f35fe13ddca2084d7b848172b2698feb4fa88025).
+
 - Total Issues: 24 (14 Fixed, 10 Acknowledged)
 - Critical Issues: 0
 - High Issues: 0
@@ -866,6 +1044,8 @@ See [full report](MixBytes%20CSM%20Performance%20Oracle%20Security%20Audit%20Rep
 See [full report](MixBytes%20Lido%20DeFi%20Wrapper%20Security%20Audit%20Report%2001-2026.pdf) for more details.
 
 ### 01-2026 Ackee Blockchain Vault Wrapper Report
+
+Audited at commit [`f35fe13`](https://github.com/lidofinance/vaults-wrapper/tree/f35fe13ddca2084d7b848172b2698feb4fa88025).
 
 - Total Issues: 14 (13 Fixed, 1 Acknowledged)
 - Critical Issues: 0
@@ -879,12 +1059,16 @@ See [full report](Ackee%20Blockchain%20Vault%20Wrapper%20Report%2001-2026.pdf) f
 
 ### 03-2026 Composable Security Lido Oracle v7.1 Security Audit
 
+Audited at commit [`b2e9296`](https://github.com/lidofinance/lido-oracle/tree/b2e92969fd35b2a1838667a290ded649ca33fbf5).
+
 - Total Issues: 1 (1 Fixed)
 - Info Issues: 1 (1 Fixed)
 
 See [full report](Composable%20Security%20Lido%20Oracle%20V7_1%20Audit%20Report.pdf) for more details.
 
 ### 03-2026 MixBytes Lido DeFi Wrapper MellowStrategyAdapter Security Audit Report 03-2026
+
+Audited at commit [`37b0999`](https://github.com/lidofinance/vaults-wrapper/tree/37b09995b8695becbaa6bcdbcfcdbc3838b8c926).
 
 - Total Issues: 9 (7 Fixed, 2 Acknowledged)
 - Critical Issues: 0
@@ -896,6 +1080,8 @@ See [full report](MixBytes%20Lido%20DeFi%20Wrapper%20MellowStrategyAdapter%20Sec
 
 ### 03-2026 MixBytes Triggerable Withdrawals Easy Track Security Audit Report
 
+Audited at commit [`bdd0483`](https://github.com/lidofinance/easy-track/tree/bdd048352fe6719b0e1f998bffdc05c6607688e0).
+
 An updated report for [the previously audited Triggerable Withdrawals Easy Tracks](#09-2025-mixbytes-lido-triggerable-withdrawals-easy-track-security-audit).
 The update includes mitigations for a vulnerability that allowed unauthorized access to the withdrawal process by duplicating keys not owned by the Node Operator.
 
@@ -904,6 +1090,8 @@ No addition issues were found.
 See [full report](MixBytes%20Lido%20Easy%20Track%20Security%20Audit%20Report%2003-26.pdf) for more details.
 
 ### 03-2026 Certora Lido V3 Security Assessment Fix Review
+
+Audited at commit [`702ef9d`](https://github.com/lidofinance/core/tree/702ef9da1bc067a996614de1e3c6a53b797fa4c2).
 
 A fix review for [the previously audited Lido V3 contracts](#12-2025-certora-lido-v3-security-audit).
 The review covered fixes to VaultHub's partial withdrawal prohibition for unhealthy vaults and related components.
@@ -919,6 +1107,8 @@ See [full report](Certora%20Lido%20V3%20Smart%20Contracts%20Security%20Assessmen
 
 ### 03-2026 MixBytes Lido V3 Security Audit
 
+Audited at commit [`702ef9d`](https://github.com/lidofinance/core/tree/702ef9da1bc067a996614de1e3c6a53b797fa4c2).
+
 An updated report for [the previously audited Lido V3 contracts](#12-2025-mixbytes-lido-v3-security-audit).
 The review covered fixes to LazyOracle's sanity checks and VaultHub's partial withdrawal handling for vaults with obligations shortfall.
 
@@ -928,6 +1118,8 @@ See [full report](MixBytes%20Lido%20v3%20Security%20Audit%20Report%2003-26.pdf) 
 
 ### 03-2026 MixBytes Lido EasyTrack stVaults Security Audit
 
+Audited at commit [`1330bcf`](https://github.com/lidofinance/easy-track/tree/1330bcff9dec5d0c800af9b7f8347268e6743181).
+
 An updated report for [the previously audited Lido V3 Easy Track contracts](#12-2025-mixbytes-lido-v3-easy-track-security-audit).
 The review covered changes to tier shareLimit validation in OperatorGrid EVMScript factories, decoupling it from the on-chain group shareLimit in favor of a hardcoded constant.
 
@@ -936,6 +1128,8 @@ No issues were found.
 See [full report](MixBytes%20Lido%20Easy%20Track%20stVaults%20Security%20Audit%20Report%2003-26.pdf) for more details.
 
 ### 04-2026 Cyfrin Lido CircuitBreaker Security Audit and Formal Verification
+
+Audited at commit [`b4b2fbc`](https://github.com/lidofinance/circuit-breaker/tree/b4b2fbc921b3191560a3fc62d502d4bb98ad99e1).
 
 An audit and Certora Prover formal verification of the CircuitBreaker emergency pause manager.
 
@@ -955,6 +1149,8 @@ See [formal verification report](Cyfrin%20CircuitBreaker%20Formal%20Verification
 
 ### 04-2026 MixBytes Lido CircuitBreaker Security Audit
 
+Audited at commit [`b4b2fbc`](https://github.com/lidofinance/circuit-breaker/tree/b4b2fbc921b3191560a3fc62d502d4bb98ad99e1).
+
 An audit of the CircuitBreaker emergency pause manager.
 
 - Total Issues: 1 (1 Fixed)
@@ -969,6 +1165,8 @@ See [full report](MixBytes%20CircuitBreaker%20Audit%20Report%2004-2026.pdf) for 
 
 ### 07-2022 Oxorio Lido L2 Smart Contracts Security Audit
 
+Audited at commit [`082e7eb`](https://github.com/lidofinance/lido-l2/tree/082e7eb59de63bd376b30886568813408d04f00b).
+
 - Total Issues: 9 (6 Fixed, 2 Acknowledged, 1 No Issue)
 - Critical Issues: 1 (1 Acknowledged)
 - Major Issues: 1 (1 Fixed)
@@ -979,6 +1177,8 @@ See [full report](L2/Lido-L2-2022-07-Oxorio-Smart-Contracts-Security-Audit-Repor
 
 ### 08-2022 Oxorio Governance Crosschain Bridges Smart Contracts Security Audit
 
+Audited at commit [`8fa25b0`](https://github.com/lidofinance/governance-crosschain-bridges/tree/8fa25b0080dd3dcc2390313631aea6796a12c9d8).
+
 - Total Issues: 8 (8 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -988,6 +1188,8 @@ See [full report](L2/Lido-L2-2022-07-Oxorio-Smart-Contracts-Security-Audit-Repor
 See [full report](L2/Governance-Crosschain-Bridges-2022-08-Oxorio-Audit%20Report.pdf) for more details.
 
 ### 09-2023 Verilog Mantle L2 ERC20 Token Bridge Audit
+
+Audited at commit [`cdd513c`](https://github.com/mantlenetworkio/lido-l2/tree/cdd513cd3d25699a8757f8e730b443a495d0240e).
 
 - Total Issues: 5 (3 Fixed, 2 Acknowledged)
 - High: 0
@@ -1010,6 +1212,8 @@ See [full report](L2/zkSync-2023-10-Cantina-Audit-Report.pdf) for more details.
 
 ### 10-2023 Diligence Linea Cross‐Chain Governance Executor Audit
 
+Audited at commit [`315308a`](https://github.com/Consensys/governance-crosschain-bridges/tree/315308a2640c696937185732159b130417f29997).
+
 - Total Issues: 1 (1 Fixed)
 - Informational: 1 (1 Fixed)
 
@@ -1017,11 +1221,15 @@ See [full report](L2/Linea-2023-10-Diligence-Cross-Chain-Governance-Executor-Aud
 
 ### 12-2023 Diligence Linea Custom Bridged Token Audit
 
+Audited at commit [`3cf8552`](https://github.com/Consensys/linea-contracts/tree/3cf85529fd4539eb06ba998030c37e47f98c528a).
+
 - Total Issues: 0
 
 See [full report](L2/Lidea-2023-12-Diligence-Custom-Bridged-Token-Audit-Report.pdf) for more details.
 
 ### 12-2023 OpenZeppelin Linea Bridge Audit
+
+Audited at commit [`f08c190`](https://github.com/Consensys/linea-contracts/tree/f08c1906855198e2dc0413a47dcb38291b7087e5).
 
 > NB: the most of the contracts and issues are related not to wstETH bridge but to the entire Linea L2 system.
 
@@ -1036,12 +1244,16 @@ See [full report](L2/Linea-2023-12-OpenZeppelin-Bridge-Audit-Report.pdf) for mor
 
 ### 01-2024 Zellic Scroll Lido Gateway Audit
 
+Audited at commit [`69224eb`](https://github.com/scroll-tech/scroll/tree/69224ebb935d499c055c7859c1c8ade57244249c).
+
 - Total Issues: 1 (1 No Issue)
 - Info Issues: 1 (1 No Issue)
 
 See [full report](L2/Scroll-2024-01-Lido-Gateway-Zellic-Audit-Report.pdf) for more details.
 
 ### 06-2024 Ackee Blockchain stETH on Optimism Audit
+
+Audited at commit [`8f19e11`](https://github.com/lidofinance/lido-l2/tree/8f19e1101a211c8f3d42af7ffcb87ab0ebcf750c).
 
 - Total Issues: 15 (10 Fixed, 5 Acknowledged)
 - Critical Issues: 0
@@ -1055,6 +1267,8 @@ See [full report](L2/stETH-on-Optimism-2024-06-Ackee-Blockchain-Audit-report.pdf
 
 ### 06-2024 MixBytes stETH on Optimism Audit
 
+Audited at commit [`a31049a`](https://github.com/lidofinance/lido-l2/tree/a31049ac8828d6d6a214b63279ff678101d55308).
+
 - Total Issues: 20 (15 Fixed, 5 Acknowledged)
 - Critical Issues: 0
 - High Issues: 1 (1 Fixed)
@@ -1064,6 +1278,8 @@ See [full report](L2/stETH-on-Optimism-2024-06-Ackee-Blockchain-Audit-report.pdf
 See [full report](L2/stETH-on-Optimism-2024-06-MixBytes-Audit-Report.pdf) for more details.
 
 ### 07-2024 Cantina wstETH on Mode Verification
+
+Audited at commit [`3c36d93`](https://github.com/lidofinance/lido-l2/tree/3c36d93cb05dbd83d854b24e071c2e5f80897272).
 
 The deployed contracts are verified against the [wstETH on Base](https://docs.lido.fi/deployed-contracts/#base) deployment.
 
@@ -1081,11 +1297,15 @@ See [full report](bsc/MixBytes%20Lido%20a.DI%20Security%20Audit%20Report%2007-20
 
 ### 08-2024 Oxorio wstETH on BNB Verification
 
+Audited at commit [`0d37b0f`](https://github.com/wormhole-foundation/example-native-token-transfers/tree/0d37b0f4975084492c72ca881c1218d6e1aae9e3).
+
 The deployed contracts are verified in accordance to the [proposal](https://research.lido.fi/t/wormhole-x-axelar-lido-bridge-implementation-for-wsteth-on-bnb-chain/6012)
 
 See full [initial](bsc/Lido-wstETH-on-BNB-Deployment-Verification-Report.pdf) and [remediated](bsc/Lido-wstETH-on-BNB-Deployment-Verification-Report-remediated.pdf) reports for more details.
 
 ### 10-2024 Quantstamp wstETH on Zircuit Verification
+
+Audited at commit [`d8b68db`](https://github.com/lidofinance/lido-l2/tree/d8b68db14a98d49aeff20bfd4ccd581a02ed3f48).
 
 The deployed contracts are verified against the [wstETH on Optimism](https://github.com/lidofinance/lido-l2) and [Governance crosschain bridges](https://github.com/lidofinance/governance-crosschain-bridges) references together with the [proposed setup](https://docs.lido.fi/token-guides/wsteth-bridging-guide#the-proposed-configuration) initialization.
 
@@ -1099,11 +1319,15 @@ See the [full report](L2/Starknet-2024-11-14-deployment-verification.pdf) for mo
 
 ### 01-2025 MixBytes stETH on Soneium Verification
 
+Audited at commit [`8f19e11`](https://github.com/lidofinance/lido-l2/tree/8f19e1101a211c8f3d42af7ffcb87ab0ebcf750c).
+
 The deployed contracts are verified against the [stETH on Optimism](https://docs.lido.fi/deployed-contracts/#optimism) deployment.
 
 See [full report](L2/stETH-on-Soneium-2025-01-MixBytes-deployment-verification.pdf) for more details.
 
 ### 02-2025 MixBytes stETH on Unichain Verification
+
+Audited at commit [`8f19e11`](https://github.com/lidofinance/lido-l2/tree/8f19e1101a211c8f3d42af7ffcb87ab0ebcf750c).
 
 The deployed contracts are verified against the [stETH on Optimism](https://docs.lido.fi/deployed-contracts/#optimism) deployment.
 
@@ -1111,11 +1335,15 @@ See [full report](L2/stETH-on-Unichain-2025-02-MixBytes-deployment-verification.
 
 ### 04-2025 MixBytes wstETH on Lisk Verification
 
+Audited at commit [`a569a49`](https://github.com/lidofinance/lido-l2/tree/a569a49966360fbd223f4bd26a8720eab3799e5f).
+
 The deployed contracts are verified in accordance to the [proposal](https://research.lido.fi/t/temperature-check-wsteth-deployment-to-lisk-and-ownership-acceptance-by-lido-nec/6669/5)
 
 See [full report](L2/wstETH-on-Lisk-2025-04-MixBytes-deployment-verification.pdf) for more details.
 
 ### 03-2026 Cantina zkSync Lido Bridge PR-85 Fix Review
+
+Audited at commit [`b5bbb12`](https://github.com/lidofinance/lido-l2/tree/b5bbb12982cc5d3279243e271ae69de6e4e6725e).
 
 Review of fixes implemented for the zkSync L1ERC20Bridge (follow-up to the [October 2023 Cantina audit](L2/zkSync-2023-10-Cantina-Audit-Report.pdf)). No additional issues were identified.
 
@@ -1283,6 +1511,8 @@ See [full report](earn/Lido%20AAVE%20Migrator%20Security%20Audit%20Report.pdf) f
 
 ### 04-2022 Lido On Polygon Smart Contracts Security Audit for PR#69
 
+Audited at commit [`1d8e469`](https://github.com/Shard-Labs/PoLido/tree/1d8e4696d9a225f9079bcaff1cb8a60c8eff8131).
+
 - Total Issues: 9 (4 Fixed, 1 Acknowledged, 1 No Issue)
 - Critical Issues: 0
 - Major Issues: 0
@@ -1292,6 +1522,8 @@ See [full report](earn/Lido%20AAVE%20Migrator%20Security%20Audit%20Report.pdf) f
 See [full report](polygon/Oxorio%20Lido%20on%20Polygon%20pr69%20report%2004-2022.pdf) for more details.
 
 ### 08-2022 Oxorio Lido on Polygon V2
+
+Audited at commit [`6b18e23`](https://github.com/lidofinance/polygon-contracts/tree/6b18e23ae258ff0aa84aecb82d8498f3c52f29e4).
 
 - Total Issues: 107 (61 Fixed, 11 Acknowledged, 35 No Issue)
 - Critical Issues: 0

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ See [full report](MixBytes%20ETH2%20Oracle%20Security%20Audit%20Report%2004-2021
 
 ### 05-2021 MixBytes Audit: stETH price oracle
 
-Audited at commit `1033b3e8` of `lidofinance/curve-merkle-oracle` (repository is private).
-
 - Total Issues: 7 (4 Fixed, 1 No issue, 2 Acknowledged)
 - Critical Issues: 0
 - Major Issues: 0
@@ -405,8 +403,6 @@ Audited at commit [`e45c4d6`](https://github.com/lidofinance/lido-dao/tree/e45c4
 See [full report](Statemind%20Lido%20V2%20Audit%20Report%2004-23.pdf) for more details.
 
 ### 05-2023 Statemind Lido V2 Upgrade Template Audit
-
-Audited at commit `a19c6b7e` of `lidofinance/lido-dao`.
 
 - Total Issues: 14 (7 Fixed, 7 Acknowledged)
 - Critical Issues: 0


### PR DESCRIPTION
Stacked on top of #161.

Adds an `Audited at commit` line linking each README entry to its reviewed source commit (the final fix commit where an audit has one). Every link was checked to be publicly reachable.

Coverage: **130 / 134**. The remaining 4 have no public source commit:
- `05-2021 MixBytes stETH price oracle`: source repo is private
- `05-2023 Statemind Lido V2 Upgrade Template`: audited commit is not public
- `10-2023 Statemind Lido roles analysis`: on-chain analysis, no source commit
- `11-2024 Nethermind wstETH on Starknet Deployment Verification`: deployment verification, no source commit
