### PR TITLE
docs: rename 'Insurance Fund' audit to 'Reserve Fund'

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ See [note](MixBytes%20Note%20on%20Deployed%20Code%20Compliance%2008-22.pdf) cont
 
 See [full report](Statemind%20MEV-Boost%20relay%20allowlist%20Security%20Audit%20Report%2009-2022.pdf) for more details.
 
-### 09-2022 Statemind Insurance Fund Audit Report
+### 09-2022 Statemind Reserve Fund Audit Report
 
 - Total Issues: 4 (1 Fixed, 3 Acknowledged)
 - Critical Issues: 0


### PR DESCRIPTION
Renames the audit section heading accordingly:

`### 09-2022 Statemind Insurance Fund Audit Report` → `### 09-2022 Statemind Reserve Fund Audit Report`

The Statemind PDF file is left unchanged — it is the external auditor's published document and still carries its original title. The `lidofinance/insurance-fund` repository URL is also left as-is, since it is the real repository name.